### PR TITLE
Fix default envs for frontend

### DIFF
--- a/frontend/src/lib/config/env.ts
+++ b/frontend/src/lib/config/env.ts
@@ -1,6 +1,6 @@
 export const SERVER_URL =
-  process.env.NEXT_PUBLIC_SERVER_URL || "http://localhost:8000";
+  process.env.NEXT_PUBLIC_SERVER_URL || "https://api.ametsowou.me";
 export const API_VERSION = process.env.NEXT_PUBLIC_API_VERSION || "v1";
 export const SERVER_PORT = process.env.NEXT_PUBLIC_SERVER_PORT || "8000";
 export const API_URL =
-  `${SERVER_URL}/${API_VERSION}` || "http://localhost:8000/v1";
+  `${SERVER_URL}/${API_VERSION}` || "https://api.ametsowou.me/v1";


### PR DESCRIPTION
This pull request updates the server configuration in the `env.ts` file to use a production API URL instead of the localhost default. 

* [`frontend/src/lib/config/env.ts`](diffhunk://#diff-efe259b46fc81f5140f023c5783851ddd45cc94012593968e19b11479cad2dc1L2-R6): Changed `SERVER_URL` and `API_URL` to default to `https://api.ametsowou.me` and `https://api.ametsowou.me/v1`, respectively, instead of the localhost equivalents.