### PR TITLE
Fix envs in docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - EMAIL_TEMPLATES_PATH=${EMAIL_TEMPLATES_PATH}
       - BACKEND_URL=${BACKEND_URL}
       - FRONTEND_URL=${FRONTEND_URL}
+      - ADMIN_EMAIL=${ADMIN_EMAIL}
 
   db:
     image: postgres:17


### PR DESCRIPTION
This pull request includes a small change to the `docker-compose.yml` file. The change adds the `ADMIN_EMAIL` environment variable to the `services` configuration, ensuring that the admin email address can be set dynamically.