### PR TITLE
Fix - remove openapi.json from production environment

### DIFF
--- a/backend/app/app.py
+++ b/backend/app/app.py
@@ -27,6 +27,7 @@ PORT = int(get_env("PORT", "8000")) or 8000
 app = FastAPI(
     docs_url=("/docs" if DEBUG else None),
     redoc_url=("/redoc" if DEBUG else None),
+    openapi_url=("/openapi.json" if DEBUG else None)
 )
 
 app.include_router(v1_auth_router)


### PR DESCRIPTION
This pull request introduces a minor change to the `backend/app/app.py` file. The change adds an `openapi_url` configuration to the `FastAPI` instance, making the OpenAPI schema available at `/openapi.json` when `DEBUG` mode is enabled.