### PR TITLE
Fix - create a volume for file storage and fix permission issues

### DIFF
--- a/backend/app/api/routes/v1/providers/file.py
+++ b/backend/app/api/routes/v1/providers/file.py
@@ -107,11 +107,11 @@ async def create_file_resource(
 
     try:
         storage.write_file(file, resource)
-    except Exception as e:
+    except Exception:
         db_session.rollback()
         raise HTTPException(
             status_code=HTTP_400_BAD_REQUEST,
-            detail=f"Failed to save file: {str(e)}",
+            detail="Failed to save file.",
         )
 
     db_session.add(resource)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
       - BACKEND_URL=${BACKEND_URL}
       - FRONTEND_URL=${FRONTEND_URL}
       - ADMIN_EMAIL=${ADMIN_EMAIL}
+    volumes:
+      - fs:/home/runner/app/fs:rw
 
   db:
     image: postgres:17
@@ -48,4 +50,5 @@ services:
       - "5432:5432"
 
 volumes:
-  postgres_data:
+  postgres_data: {}
+  fs: {}


### PR DESCRIPTION
This pull request includes changes to improve error handling in the backend and updates to the `docker-compose.yml` file to enhance file storage configuration. Below is a summary of the most important changes:

### Backend error handling improvements:
* Updated the exception handling in the `create_file_resource` function in `file.py` to remove the use of the exception variable `e` and provide a more generic error message when a file save operation fails.

### Docker Compose updates for file storage:
* Added a new `volumes` configuration to the `services` section in `docker-compose.yml`, enabling a writable file system mount (`fs:/home/runner/app/fs:rw`) for the backend service.
* Defined a new `fs` volume in the `volumes` section of `docker-compose.yml` to support the backend file storage.