### PR TITLE
fix: remove unused props in PostViewClient img component

### DIFF
--- a/frontend/src/app/(main)/post/[slug]/PostViewClient.tsx
+++ b/frontend/src/app/(main)/post/[slug]/PostViewClient.tsx
@@ -404,7 +404,7 @@ export default function PostViewClient({ slug }: PostViewClientProps) {
                       {children}
                     </a>
                   ),
-                  img: ({ alt, src, ...props }: React.ImgHTMLAttributes<HTMLImageElement>) => (
+                  img: ({ alt, src }: React.ImgHTMLAttributes<HTMLImageElement>) => (
                     <Image
                       className="rounded-lg my-6 max-w-full h-auto"
                       alt={alt || ""}


### PR DESCRIPTION
- Fix TypeScript error: 'props' is defined but never used
- Remove unused ...props destructuring from img component in ReactMarkdown
- Next.js Image component doesn't need the additional HTML img props
- Maintains functionality while fixing linting error