### PR TITLE
fix: add api.ametsowou.me to Next.js image domains

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -5,6 +5,11 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: "https",
+        hostname: "api.ametsowou.me",
+        pathname: "/v1/resources/**",
+      },
+      {
+        protocol: "https",
         hostname: "ametsowou.me",
         pathname: "/v1/resources/**",
       },


### PR DESCRIPTION
- Fix 400 error: "url" parameter is not allowed
- Add api.ametsowou.me hostname to remotePatterns in next.config.ts
- Keep both api.ametsowou.me and ametsowou.me for flexibility
- This allows Next.js Image optimization for external API resources

Fixes the production issue where images from the API domain were being blocked by Next.js image optimization.