### PR TITLE
Fix: removed potential security issue giving global permission on all…

### DIFF
--- a/backend/app/api/routes/v1/providers/comment.py
+++ b/backend/app/api/routes/v1/providers/comment.py
@@ -47,7 +47,7 @@ async def create_comment(
         PermissionBuilder()
         .forRole(rw_role)
         .withActionName(ACTION_READWRITE)
-        .withResourceName(str(comment.id))
+        .withResourceId(str(comment.id))
         .withResourceName(COMMENT_RESOURCE)
         .make()
     )


### PR DESCRIPTION
This pull request updates the `create_comment` function in `comment.py` to fix a parameter mismatch in the `PermissionBuilder` configuration.

* [`backend/app/api/routes/v1/providers/comment.py`](diffhunk://#diff-3b525ffaf9d35e6b911573db82c503f0156412face1e36c43c796515a38c8e33L50-R50): Replaced `.withResourceName(str(comment.id))` with `.withResourceId(str(comment.id))` to correctly specify the resource ID instead of the resource name.