### PR TITLE
Fix: Fixed bad condition for public stats

### DIFF
--- a/backend/app/api/routes/v1/providers/stats.py
+++ b/backend/app/api/routes/v1/providers/stats.py
@@ -18,7 +18,7 @@ async def get_public_stats(db_session: Session):
     total_articles = db_session.exec(
         select(func.count())
         .select_from(Post)
-        .where(Post.published == True, Post.archived != False)
+        .where(Post.published == True, Post.archived == False)
     ).one()
     featured_articles = db_session.exec(
         select(func.count())


### PR DESCRIPTION
This pull request includes a small fix to the `backend/app/api/routes/v1/providers/stats.py` file. The change updates the condition for filtering archived posts to correctly check if `Post.archived` is `False` instead of `!= False`.